### PR TITLE
Improved death & checkpoint logic

### DIFF
--- a/Platformer2016.gmx/Platformer2016.project.gmx
+++ b/Platformer2016.gmx/Platformer2016.project.gmx
@@ -37,6 +37,7 @@
     <script>scripts\scr_menu.gml</script>
     <script>scripts\scr_pause.gml</script>
     <script>scripts\scr_loadGame.gml</script>
+    <script>scripts\scr_death.gml</script>
   </scripts>
   <fonts name="fonts">
     <font>fonts\fnt_default</font>

--- a/Platformer2016.gmx/objects/obj_checkpoint.object.gmx
+++ b/Platformer2016.gmx/objects/obj_checkpoint.object.gmx
@@ -59,6 +59,7 @@ if(place_meeting(x, y, obj_scottStill))
     global.checkpointR = room;
 }
 
+// If the checkpoint is in this room, change to active sprite
 if(global.checkpointR == room)
 {
     if(global.checkpoint == id)

--- a/Platformer2016.gmx/objects/obj_ghost.object.gmx
+++ b/Platformer2016.gmx/objects/obj_ghost.object.gmx
@@ -119,6 +119,10 @@ if(place_meeting(x, y, obj_scottStill))
         room_goto(rm_initialise);
     }
     */
+    else
+    {
+        scr_death();
+    }
 }  
 
 // Animate

--- a/Platformer2016.gmx/objects/obj_scottstill.object.gmx
+++ b/Platformer2016.gmx/objects/obj_scottstill.object.gmx
@@ -35,6 +35,7 @@ movespeed = 10;
 
 // Checkpoint spawn logic
 
+/*
 // if current active checkpoint is NOT in this room when we already spawned
 // then there is no active checkpoint
 // AKA original spawn location
@@ -43,6 +44,11 @@ if (global.checkpointR == room)
     x = global.checkpointx;
     y = global.checkpointy;
 }
+*/
+
+// As create event, store X and Y position of player spawn
+startx = x;
+starty = y;
 </string>
           </argument>
         </arguments>
@@ -137,30 +143,6 @@ else
         </arguments>
       </action>
     </event>
-    <event eventtype="4" ename="obj_ghost">
-      <action>
-        <libid>1</libid>
-        <id>603</id>
-        <kind>7</kind>
-        <userelative>0</userelative>
-        <isquestion>0</isquestion>
-        <useapplyto>-1</useapplyto>
-        <exetype>2</exetype>
-        <functionname></functionname>
-        <codestring></codestring>
-        <whoName>self</whoName>
-        <relative>0</relative>
-        <isnot>0</isnot>
-        <arguments>
-          <argument>
-            <kind>1</kind>
-            <string>instance_destroy();
-room_restart();
-</string>
-          </argument>
-        </arguments>
-      </action>
-    </event>
     <event eventtype="7" enumb="4">
       <action>
         <libid>1</libid>
@@ -214,9 +196,7 @@ file_text_close(SaveFile);
         <arguments>
           <argument>
             <kind>1</kind>
-            <string>instance_destroy();
-
-room_restart();
+            <string>scr_death();
 </string>
           </argument>
         </arguments>

--- a/Platformer2016.gmx/rooms/rm_level1.room.gmx
+++ b/Platformer2016.gmx/rooms/rm_level1.room.gmx
@@ -439,7 +439,6 @@
     <instance objName="obj_block" x="30752" y="1824" name="inst_051DA6ED" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
     <instance objName="obj_block" x="30624" y="1824" name="inst_FBD946AC" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
     <instance objName="obj_portal" x="30688" y="1664" name="inst_233F3156" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
-    <instance objName="obj_scottStill" x="352" y="1440" name="inst_46512E66" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
     <instance objName="obj_ghostNoFall" x="3136" y="1536" name="inst_736336EA" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
     <instance objName="obj_ghostNoFall" x="13120" y="256" name="inst_AE3955C5" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
     <instance objName="obj_ghostNoFall" x="13440" y="96" name="inst_9A478286" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
@@ -641,6 +640,7 @@
     <instance objName="obj_block" x="-64" y="1472" name="inst_3C79DB20" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
     <instance objName="obj_block" x="-64" y="1344" name="inst_9CE8F8A3" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
     <instance objName="obj_block" x="-64" y="1216" name="inst_3E120DB9" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
+    <instance objName="obj_scottStill" x="29728" y="1472" name="inst_C14A73EC" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
   </instances>
   <tiles/>
   <PhysicsWorld>0</PhysicsWorld>

--- a/Platformer2016.gmx/rooms/rm_level2.room.gmx
+++ b/Platformer2016.gmx/rooms/rm_level2.room.gmx
@@ -51,11 +51,11 @@
     <view visible="0" objName="&lt;undefined&gt;" xview="0" yview="0" wview="1024" hview="768" xport="0" yport="0" wport="1024" hport="768" hborder="32" vborder="32" hspeed="-1" vspeed="-1"/>
   </views>
   <instances>
-    <instance objName="obj_scottStill" x="64" y="1408" name="inst_93065C65" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
-    <instance objName="obj_block" x="64" y="1856" name="inst_6857365F" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
-    <instance objName="obj_block" x="352" y="1568" name="inst_209FC59E" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
-    <instance objName="obj_block" x="672" y="1280" name="inst_510EA956" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
-    <instance objName="obj_block" x="960" y="928" name="inst_782DE174" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
+    <instance objName="obj_block" x="64" y="576" name="inst_6857365F" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
+    <instance objName="obj_block" x="192" y="576" name="inst_209FC59E" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
+    <instance objName="obj_block" x="320" y="576" name="inst_510EA956" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
+    <instance objName="obj_block" x="448" y="576" name="inst_782DE174" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
+    <instance objName="obj_scottStill" x="192" y="288" name="inst_D1810D31" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
   </instances>
   <tiles/>
   <PhysicsWorld>0</PhysicsWorld>

--- a/Platformer2016.gmx/scripts/scr_death.gml
+++ b/Platformer2016.gmx/scripts/scr_death.gml
@@ -1,0 +1,14 @@
+// Check if active checkpoint is in current room, go to that checkpoint
+if(global.checkpointR == room)
+{
+    obj_scottStill.x = global.checkpointx;
+    obj_scottStill.y = global.checkpointy;
+}
+// else, go spawn in beginning
+// restart room added to prevent infinite stuck loops in the off chance
+else
+{
+    obj_scottStill.x = obj_scottStill.startx;
+    obj_scottStill.x = obj_scottStill.starty;
+    room_restart();
+}


### PR DESCRIPTION
ADDITIONS:
+added comments to checkpoint logic code
+scr_death added to reroute checkpoint and death logic
+obj_scottStill create event added startx,y variables

CHANGES:
*obj_ghost step added else statement to lead to scr_death
*obj_scottStill create commented out checkpoint spawn logic code
*obj_scottStill removed collision with obj_ghost event
*obj_scottStill outside room event changed to run scr_death. Removed
instance_destroy();

ISSUES:
*see previous patch
-Menu logic no longer functioning on start game. Code commented out to
start back on initialise in the meanwhile
-Inefficient code for collision check under obj_ghostNoFall to not fall
off ledge

-pressing escape aka menu options and just attempting to start new game
with start game causes glitch out
-entering 2nd level causes to spawn randomly and fall off with no
respawn. Game freeze(?)
